### PR TITLE
Add paymentMethod, orderId and validate required fields

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -42,10 +42,20 @@ class PurchaseRequest extends AbstractRequest
     {
         return $this->setParameter('secretKey', $value);
     }
+    
+    public function getOrderId()
+    {
+        return $this->getParameter('orderId');
+    }
+
+    public function setOrderId($value)
+    {
+        return $this->setParameter('orderId', $value);
+    }
 
     public function getData()
     {
-        $this->validate('merchantId', 'keyVersion', 'secretKey', 'amount');
+        $this->validate('merchantId', 'keyVersion', 'secretKey', 'amount', 'transactionId', 'returnUrl', 'currency');
 
         $data = array();
         $data['Data'] = implode(
@@ -58,6 +68,8 @@ class PurchaseRequest extends AbstractRequest
                 'automaticResponseUrl='.$this->getReturnUrl(),
                 'transactionReference='.$this->getTransactionId(),
                 'keyVersion='.$this->getKeyVersion(),
+                'paymentMeanBrandList='.$this->getPaymentMethod(),
+                'orderId='.$this->getOrderId(),
             )
         );
         $data['InterfaceVersion'] = 'HP_1.0';

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -17,13 +17,15 @@ class PurchaseRequestTest extends TestCase
                 'amount' => '10.00',
                 'currency' => 'EUR',
                 'returnUrl' => 'https://www.example.com/return',
+                'transactionId' => '5',
             )
         );
     }
 
     public function testGetData()
     {
-        $this->request->setTransactionId('5');
+        $this->request->setPaymentMethod('IDEAL');
+        $this->request->setOrderId('6');
 
         $data = $this->request->getData();
 
@@ -34,6 +36,8 @@ class PurchaseRequestTest extends TestCase
         $this->assertContains('normalReturnUrl=https://www.example.com/return', $data['Data']);
         $this->assertContains('automaticResponseUrl=https://www.example.com/return', $data['Data']);
         $this->assertContains('transactionReference=5', $data['Data']);
+        $this->assertContains('paymentMeanBrandList=IDEAL', $data['Data']);
+        $this->assertContains('orderId=6', $data['Data']);
 
         $this->assertSame('HP_1.0', $data['InterfaceVersion']);
     }


### PR DESCRIPTION
orderId can be added to provide a order ID to the user, paymentMethod can be set directly.
currency, transactionId and returnUrl are also required. Fixes #1 also.

Todo:
- [x] add tests
