### PR TITLE
Add more methods to CompletePurchaseResponse

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -67,16 +67,13 @@ class CompletePurchaseResponse extends AbstractResponse
     {
         $code = $this->getCode();
         $status = array(
-            '00' => 'Success',
-            '05' => 'Failure',
-            '17' => 'Cancelled',
-            '60' => 'Open',
-            '90' => 'Failure sending in',
-            '97' => 'Expired',
-            '99' => 'Started',
+            '00' => 'SUCCESS',
+            '17' => 'CANCELLED',
+            '60' => 'PENDING',
+            '97' => 'EXPIRED',
         );
 
-        return isset($status[$code]) ? $status[$code] : 'Unknown';
+        return isset($status[$code]) ? $status[$code] : 'FAILED';
     }
 
     public function getTransactionId()

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -14,7 +14,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('00', $response->getCode());
-        $this->assertSame('Success', $response->getStatus());
+        $this->assertSame('SUCCESS', $response->getStatus());
         $this->assertSame('Transaction successful. Authorisation accepted (credit card).', $response->getMessage());
     }
 
@@ -43,15 +43,15 @@ class CompletePurchaseResponseTest extends TestCase
     
     public function testGetData()
     {
-        $data = array('Data' => 'orderId=6|transactionReference=5|authorisationId=123|paymentMeanBrand=IDEAL|responseCode=05');
+        $data = array('Data' => 'orderId=6|transactionReference=5|authorisationId=123|paymentMeanBrand=IDEAL|responseCode=17');
         $response = new CompletePurchaseResponse($this->getMockRequest(), $data);
         
         $this->assertSame("6", $response->getOrderId());
         $this->assertSame("5", $response->getTransactionId());
         $this->assertSame("123", $response->getAuthorisationId());
         $this->assertSame("IDEAL", $response->getPaymentMethod());
-        $this->assertSame("Failure", $response->getStatus());
-        $this->assertSame("Refused.", $response->getMessage());
+        $this->assertSame("CANCELLED", $response->getStatus());
+        $this->assertSame("Cancellation of payment by user.", $response->getMessage());
     }
     
     public function testUnknownResponseCode()
@@ -62,7 +62,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertSame('AA', $response->getCode());
-        $this->assertSame('Unknown', $response->getStatus());
+        $this->assertSame('FAILED', $response->getStatus());
         $this->assertNull($response->getMessage());
     }
 }


### PR DESCRIPTION
Allow to get some more information about the response, like the transactionId/orderId/AuthorisationId for manual checking.
There are some more methods available sometimes, you want me to add them as well? https://www.rabobank.nl/images/integratiehandleiding_rabo_omnikassa_en_version_7_1_april_2014_final_2_0_29637101.pdf#page=17

Todo:
- [x] add tests
