### PR TITLE
automaticResponseUrl can be different then normalReturnUrl

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -55,7 +55,7 @@ class PurchaseRequest extends AbstractRequest
                 'currencyCode='.$this->getCurrencyNumeric(),
                 'merchantId='.$this->getMerchantId(),
                 'normalReturnUrl='.$this->getReturnUrl(),
-                'automaticResponseUrl='.$this->getReturnUrl(),
+                'automaticResponseUrl='.($this->getNotifyUrl() ?: $this->getReturnUrl()),
                 'transactionReference='.$this->getTransactionId(),
                 'keyVersion='.$this->getKeyVersion(),
             )

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -37,6 +37,16 @@ class PurchaseRequestTest extends TestCase
 
         $this->assertSame('HP_1.0', $data['InterfaceVersion']);
     }
+    
+    public function testGetDifferentNotififyUrl()
+    {
+        $this->request->setNotifyUrl('https://www.example.com/notify');
+
+        $data = $this->request->getData();
+        
+        $this->assertContains('normalReturnUrl=https://www.example.com/return', $data['Data']);
+        $this->assertContains('automaticResponseUrl=https://www.example.com/notify', $data['Data']);
+    }
 
     public function testGenerateSignature()
     {


### PR DESCRIPTION
I'm not sure what the best way is. The automaticResponseUrl can be different then the normalReturnUrl. So I guess the automatic one is supposed to be the NotifyUrl? But it would be more developer-friendly to fallback on the ReturnUrl by default.
Or should is also be possible to disable the automatic response?

To do:
- [x] add tests
