### PR TITLE
Set transactionReference if not set

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -76,9 +76,14 @@ class CompletePurchaseResponse extends AbstractResponse
         return isset($status[$code]) ? $status[$code] : 'FAILED';
     }
 
-    public function getTransactionId()
+    public function getTransactionReference()
     {
         return isset($this->i_data['transactionReference']) ? $this->i_data['transactionReference'] : null;
+    }
+    
+    public function getTransactionId()
+    {
+        return isset($this->i_data['orderId']) ? $this->i_data['orderId'] : null;
     }
 
     public function getPaymentMethod()
@@ -89,11 +94,6 @@ class CompletePurchaseResponse extends AbstractResponse
     public function getAuthorisationId()
     {
         return isset($this->i_data['authorisationId']) ? $this->i_data['authorisationId'] : null;
-    }
-
-    public function getOrderId()
-    {
-        return isset($this->i_data['orderId']) ? $this->i_data['orderId'] : null;
     }
 
     /**

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -43,21 +43,13 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('secretKey', $value);
     }
     
-    public function getOrderId()
-    {
-        return $this->getParameter('orderId');
-    }
-
-    public function setOrderId($value)
-    {
-        return $this->setParameter('orderId', $value);
-    }
-
     public function getData()
     {
         $this->validate('merchantId', 'keyVersion', 'secretKey', 'amount', 'returnUrl', 'currency');
         
-        $transRef = $this->getTransactionReference() ?: $this->getTransactionId();
+        if (null === $this->getTransactionReference()) {
+            $this->setTransactionReference(md5(time() . $this->getTransactionId()));
+        }
 
         $data = array();
         $data['Data'] = implode(
@@ -68,10 +60,10 @@ class PurchaseRequest extends AbstractRequest
                 'merchantId='.$this->getMerchantId(),
                 'normalReturnUrl='.$this->getReturnUrl(),
                 'automaticResponseUrl='.($this->getNotifyUrl() ?: $this->getReturnUrl()),
-                'transactionReference='.$transRef,
+                'transactionReference='.$this->getTransactionReference(),
                 'keyVersion='.$this->getKeyVersion(),
                 'paymentMeanBrandList='.$this->getPaymentMethod(),
-                'orderId='.$this->getOrderId(),
+                'orderId='.$this->getTransactionId(),
             )
         );
         $data['InterfaceVersion'] = 'HP_1.0';

--- a/src/Message/PurchaseResponse.php
+++ b/src/Message/PurchaseResponse.php
@@ -34,4 +34,9 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
     {
         return $this->data;
     }
+    
+    public function getTransactionReference()
+    {
+        return $this->getRequest()->getTransactionReference();
+    }
 }

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -43,11 +43,11 @@ class CompletePurchaseResponseTest extends TestCase
     
     public function testGetData()
     {
-        $data = array('Data' => 'orderId=6|transactionReference=5|authorisationId=123|paymentMeanBrand=IDEAL|responseCode=17');
+        $data = array('Data' => 'orderId=5|transactionReference=6|authorisationId=123|paymentMeanBrand=IDEAL|responseCode=17');
         $response = new CompletePurchaseResponse($this->getMockRequest(), $data);
         
-        $this->assertSame("6", $response->getOrderId());
         $this->assertSame("5", $response->getTransactionId());
+        $this->assertSame("6", $response->getTransactionReference());
         $this->assertSame("123", $response->getAuthorisationId());
         $this->assertSame("IDEAL", $response->getPaymentMethod());
         $this->assertSame("CANCELLED", $response->getStatus());

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -25,7 +25,7 @@ class PurchaseRequestTest extends TestCase
     public function testGetData()
     {
         $this->request->setPaymentMethod('IDEAL');
-        $this->request->setOrderId('6');
+        $this->request->setTransactionReference('6');
 
         $data = $this->request->getData();
 
@@ -35,13 +35,13 @@ class PurchaseRequestTest extends TestCase
         $this->assertContains('keyVersion=ver', $data['Data']);
         $this->assertContains('normalReturnUrl=https://www.example.com/return', $data['Data']);
         $this->assertContains('automaticResponseUrl=https://www.example.com/return', $data['Data']);
-        $this->assertContains('transactionReference=5', $data['Data']);
+        $this->assertContains('orderId=5', $data['Data']);
         $this->assertContains('paymentMeanBrandList=IDEAL', $data['Data']);
-        $this->assertContains('orderId=6', $data['Data']);
+        $this->assertContains('transactionReference=6', $data['Data']);
 
         $this->assertSame('HP_1.0', $data['InterfaceVersion']);
     }
-    
+
     public function testGetDifferentNotififyUrl()
     {
         $this->request->setNotifyUrl('https://www.example.com/notify');
@@ -80,6 +80,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertInstanceOf('\Omnipay\Rabobank\Message\PurchaseResponse', $response);
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
+        $this->assertNotNull($response->getTransactionReference());
 
         $data = $response->getRedirectData();
         $this->assertArrayHasKey('Data', $data);


### PR DESCRIPTION
And change orderId to transactionId.

 - Generate transactionReference if not set
 - orderId -> transactionId
 - pass transactionReference to purchaseResponse
 - fix transactionReference in completePurchaseResponse

Not sure if we should add some random code, but I guess most people either set the transactionId or don't have more then 1 purchase per second.

But this does break the people using setOrderId, or should we add those as methods referencing the transactionId, for BC?