### PR TITLE
Customer Language added

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -53,6 +53,16 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('orderId', $value);
     }
 
+    public function getCustomerLanguage()
+    {
+        return $this->getParameter('customerLanguage');
+    }
+
+    public function setCustomerLanguage($value)
+    {
+        return $this->setParameter('customerLanguage', $value);
+    }
+
     public function getData()
     {
         $this->validate('merchantId', 'keyVersion', 'secretKey', 'amount', 'returnUrl', 'currency');
@@ -72,6 +82,7 @@ class PurchaseRequest extends AbstractRequest
                 'keyVersion='.$this->getKeyVersion(),
                 'paymentMeanBrandList='.$this->getPaymentMethod(),
                 'orderId='.$this->getOrderId(),
+                'customerLanguage='.$this->getCustomerLanguage()
             )
         );
         $data['InterfaceVersion'] = 'HP_1.0';

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -26,6 +26,7 @@ class PurchaseRequestTest extends TestCase
     {
         $this->request->setPaymentMethod('IDEAL');
         $this->request->setOrderId('6');
+        $this->request->setCustomerLanguage('EN');
 
         $data = $this->request->getData();
 
@@ -38,6 +39,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertContains('transactionReference=5', $data['Data']);
         $this->assertContains('paymentMeanBrandList=IDEAL', $data['Data']);
         $this->assertContains('orderId=6', $data['Data']);
+        $this->assertContains('customerLanguage=EN', $data['Data']);
 
         $this->assertSame('HP_1.0', $data['InterfaceVersion']);
     }


### PR DESCRIPTION
Possibility added to set the customer language used when making the payment.

If the customerLanguage isn't set the Rabobank will use the browser language as before.