### PR TITLE
We experienced a bug with the generated response signature

### DIFF
--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -43,9 +43,10 @@ class AbstractRabobankResponse extends AbstractResponse
         if (!isset($this->data['signature'])) {
             return;
         }
-
-        $signatureData = $this->data;
-        unset($signatureData['signature']);
+        
+        $signatureData = [
+            'redirectUrl' => $this->data['redirectUrl'] ?? '',
+        ];
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));
 

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -45,7 +45,7 @@ class AbstractRabobankResponse extends AbstractResponse
         }
         
         $signatureData = [
-            'redirectUrl' => $this->data['redirectUrl'] ?? '',
+            'redirectUrl' => $this->data['redirectUrl'],
         ];
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -44,11 +44,9 @@ class AbstractRabobankResponse extends AbstractResponse
             return;
         }
         
-        $redirectUrl = !empty($this->data['redirectUrl']) ? $this->data['redirectUrl'] : '';
-        
-        $signatureData = [
-            'redirectUrl' => $redirectUrl,
-        ];
+        $signatureData = $this->data;
+        unset($signatureData['signature']);
+        unset($signatureData['timestamp']);
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));
 

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -44,8 +44,10 @@ class AbstractRabobankResponse extends AbstractResponse
             return;
         }
         
+        $redirectUrl = !empty($this->data['redirectUrl']) ? $this->data['redirectUrl'] : '';
+        
         $signatureData = [
-            'redirectUrl' => $this->data['redirectUrl'],
+            'redirectUrl' => $redirectUrl,
         ];
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));


### PR DESCRIPTION
Omnikassa responded with a json object with 3 key values:
signature, timestamp and the redirectUrl.

The documentation states that the signature is created based on the redirectUrl. The code only stripped the signature from the response data and tried to create the same signature. 

This could nog work since timestamp was included!

I turned it around by getting the redirectUrl from the response and creating a new array with only this value.

Could need some feedback but i had to use it in a production site due to the signature mismatch!