### PR TITLE
Add completePurchase method

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -95,7 +95,10 @@ class Gateway extends AbstractGateway
 
     public function completePurchase(array $parameters = [])
     {
+        /** @var CompletePurchaseRequest $request */
+        $request = $this->createRequest(CompletePurchaseRequest::class, $parameters);
 
+        return $request;
     }
 
     /**
@@ -105,7 +108,7 @@ class Gateway extends AbstractGateway
     public function status(array $parameters = [])
     {
         /** @var StatusRequest $request */
-        $request = $this->createRequest(CompletePurchaseRequest::class, $parameters);
+        $request = $this->createRequest(StatusRequest::class, $parameters);
 
         return $request;
     }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Rabobank;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\Rabobank\Message\Request\CompletePurchaseRequest;
 use Omnipay\Rabobank\Message\Request\PurchaseRequest;
 use Omnipay\Rabobank\Message\Request\StatusRequest;
 
@@ -92,6 +93,11 @@ class Gateway extends AbstractGateway
         return $request;
     }
 
+    public function completePurchase(array $parameters = [])
+    {
+
+    }
+
     /**
      * @param  array $parameters
      * @return StatusRequest
@@ -99,7 +105,7 @@ class Gateway extends AbstractGateway
     public function status(array $parameters = [])
     {
         /** @var StatusRequest $request */
-        $request = $this->createRequest(StatusRequest::class, $parameters);
+        $request = $this->createRequest(CompletePurchaseRequest::class, $parameters);
 
         return $request;
     }

--- a/src/Message/Request/AbstractRabobankRequest.php
+++ b/src/Message/Request/AbstractRabobankRequest.php
@@ -124,7 +124,7 @@ abstract class AbstractRabobankRequest extends AbstractRequest
         ]);
 
         if (!isset($data['token'])) {
-            throw new InvalidResponseException($data['consumerMessage']);
+            throw new InvalidResponseException($data['consumerMessage'], $data['errorCode']);
         }
         
         return $data['token'];

--- a/src/Message/Request/AbstractRabobankRequest.php
+++ b/src/Message/Request/AbstractRabobankRequest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Rabobank\Message\Request;
 
+use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\Message\AbstractRequest;
 use Omnipay\Rabobank\Gateway;
@@ -122,6 +123,10 @@ abstract class AbstractRabobankRequest extends AbstractRequest
             'Authorization' => 'Bearer '.$this->gateway->getRefreshToken(),
         ]);
 
+        if (!isset($data['token'])) {
+            throw new InvalidResponseException($data['consumerMessage']);
+        }
+        
         return $data['token'];
     }
 

--- a/src/Message/Request/CompletePurchaseRequest.php
+++ b/src/Message/Request/CompletePurchaseRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Omnipay\Rabobank\Message\Request;
+
+use Omnipay\Rabobank\Message\Response\CompletePurchaseResponse;
+
+/**
+ * Create a payment with the Rabobank OmniKassa API.
+ */
+class CompletePurchaseRequest extends PurchaseRequest
+{
+    public function sendData($data)
+    {
+        return $this->response = new CompletePurchaseResponse($this, $data);
+    }
+}

--- a/src/Message/Request/CompletePurchaseRequest.php
+++ b/src/Message/Request/CompletePurchaseRequest.php
@@ -9,6 +9,15 @@ use Omnipay\Rabobank\Message\Response\CompletePurchaseResponse;
  */
 class CompletePurchaseRequest extends PurchaseRequest
 {
+    public function getData()
+    {
+        $data = $this->httpRequest->query->all();
+        $data['order_id'] = $this->httpRequest->query->get('order_id');
+        $data['status'] = $this->httpRequest->query->get('status');
+        $data['signature'] = $this->httpRequest->query->get('order_id');
+        return $data;
+    }
+    
     public function sendData($data)
     {
         return $this->response = new CompletePurchaseResponse($this, $data);

--- a/src/Message/Request/CompletePurchaseRequest.php
+++ b/src/Message/Request/CompletePurchaseRequest.php
@@ -11,11 +11,7 @@ class CompletePurchaseRequest extends PurchaseRequest
 {
     public function getData()
     {
-        $data = $this->httpRequest->query->all();
-        $data['order_id'] = $this->httpRequest->query->get('order_id');
-        $data['status'] = $this->httpRequest->query->get('status');
-        $data['signature'] = $this->httpRequest->query->get('order_id');
-        return $data;
+        return $this->httpRequest->query->all();
     }
     
     public function sendData($data)

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Rabobank\Message\Response;
 
 use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Rabobank\Exception\InvalidSignatureException;
 use Omnipay\Rabobank\Message\Request\AbstractRabobankRequest;
 
@@ -18,10 +19,12 @@ class AbstractRabobankResponse extends AbstractResponse
      * @param array $data
      *
      * @throws InvalidSignatureException
+     * @throws InvalidResponseException
      */
     public function __construct(AbstractRabobankRequest $request, $data)
     {
         parent::__construct($request, $data);
+        $this->validateResponse();
         $this->validateSignature();
     }
 
@@ -33,6 +36,18 @@ class AbstractRabobankResponse extends AbstractResponse
     public function isSuccessful()
     {
         return isset($this->data['signature']);
+    }
+
+    /**
+     * Check if we've received an error
+     *
+     * @throws InvalidResponseException
+     */
+    protected function validateResponse()
+    {
+        if (isset($this->data['errorCode']) && isset($this->data['consumerMessage'])) {
+            throw new InvalidResponseException($this->data['consumerMessage'], $this->data['errorCode']);
+        }
     }
 
     /**

--- a/src/Message/Response/CompletePurchaseResponse.php
+++ b/src/Message/Response/CompletePurchaseResponse.php
@@ -7,13 +7,52 @@ use Omnipay\Rabobank\Message\Request\AbstractRabobankRequest;
 
 class CompletePurchaseResponse extends PurchaseResponse
 {
-    public function __construct(AbstractRabobankRequest $request, $data)
+    public function test($method = 'test')
     {
-        parent::__construct($request, $data);
-
         echo "<pre>";
-        print_r($data);
+        print_r($method . PHP_EOL);
+        print_r($this->data);
         echo "</pre>";
         exit();
+    }
+
+    public function isSuccessful()
+    {
+        $this->test('isSuccessful');
+    }
+
+    public function getCode()
+    {
+        $this->test('getCode');
+    }
+
+    public function getMessage()
+    {
+        $this->test('getMessage');
+    }
+
+    public function getStatus()
+    {
+        $this->test('getStatus');
+    }
+
+    public function getTransactionId()
+    {
+        $this->test('getTransactionId');
+    }
+
+    public function getPaymentMethod()
+    {
+        $this->test('getPaymentMethod');
+    }
+
+    public function getAuthorisationId()
+    {
+        $this->test('getAuthorisationId');
+    }
+
+    public function getOrderId()
+    {
+        $this->test('getOrderId');
     }
 }

--- a/src/Message/Response/CompletePurchaseResponse.php
+++ b/src/Message/Response/CompletePurchaseResponse.php
@@ -2,57 +2,15 @@
 
 namespace Omnipay\Rabobank\Message\Response;
 
-use Omnipay\Common\Message\RedirectResponseInterface;
-use Omnipay\Rabobank\Message\Request\AbstractRabobankRequest;
-
-class CompletePurchaseResponse extends PurchaseResponse
+class CompletePurchaseResponse extends AbstractRabobankResponse
 {
-    public function test($method = 'test')
-    {
-        echo "<pre>";
-        print_r($method . PHP_EOL);
-        print_r($this->data);
-        echo "</pre>";
-        exit();
-    }
-
     public function isSuccessful()
     {
-        $this->test('isSuccessful');
-    }
-
-    public function getCode()
-    {
-        $this->test('getCode');
-    }
-
-    public function getMessage()
-    {
-        $this->test('getMessage');
-    }
-
-    public function getStatus()
-    {
-        $this->test('getStatus');
-    }
-
-    public function getTransactionId()
-    {
-        $this->test('getTransactionId');
-    }
-
-    public function getPaymentMethod()
-    {
-        $this->test('getPaymentMethod');
-    }
-
-    public function getAuthorisationId()
-    {
-        $this->test('getAuthorisationId');
+        return isset($this->data['status']) && $this->data['status'] === 'COMPLETED';
     }
 
     public function getOrderId()
     {
-        $this->test('getOrderId');
+        return isset($this->data['order_id']) ? $this->data['order_id'] : null;
     }
 }

--- a/src/Message/Response/CompletePurchaseResponse.php
+++ b/src/Message/Response/CompletePurchaseResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Omnipay\Rabobank\Message\Response;
+
+use Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\Rabobank\Message\Request\AbstractRabobankRequest;
+
+class CompletePurchaseResponse extends PurchaseResponse
+{
+    public function __construct(AbstractRabobankRequest $request, $data)
+    {
+        parent::__construct($request, $data);
+
+        echo "<pre>";
+        print_r($data);
+        echo "</pre>";
+        exit();
+    }
+}


### PR DESCRIPTION
Some [Omnipay plugins](https://github.com/silverstripe/silverstripe-omnipay) require the completePurchase method to complete a payment. This method was in version 2 but removed with the updates to the new Omnikassa 2. I believe this decision was made because the Omnikassa also calls a webhook with the final verdict regarding the payment.

The added completePurchase method simply checks the status of the returned response. But it feels a bit iffy because it is based on the query parameters..  Would appreciate it a lot if someone could review and hear their ideas. 